### PR TITLE
ignore linting warnings for test-component

### DIFF
--- a/src/tests/components/test-component.ts
+++ b/src/tests/components/test-component.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {Component} from '../../index';
 
 export const selector = '[taiko-component="test-component"]';


### PR DESCRIPTION
removes the warnings for the use of `console.log` statements from the test-component